### PR TITLE
fix: prevent user from hitting DK1 in fn layers

### DIFF
--- a/keyboards/keychron/q11/ansi_encoder/keymaps/ecpgpp_qwerty_lafayette/keymap.c
+++ b/keyboards/keychron/q11/ansi_encoder/keymaps/ecpgpp_qwerty_lafayette/keymap.c
@@ -185,6 +185,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 for (int i = 0; i < strlen("flip"); i++) {
                     tap_code(KC_BSPC);
                 }
+                tap_code(KC_SPC);
             }
             break;
     }
@@ -375,7 +376,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         RGB_TOG,  _______,  KC_BRID,  KC_BRIU,  KC_TASK,  KC_FLXP,  RGB_VAD,   RGB_VAI,  KC_MPRV,  KC_MPLY,  KC_MNXT,  KC_MUTE,  KC_VOLD,    KC_VOLU,  _______,  _______,  RGB_TOG,
         _______,  _______,  _______,  _______,  _______,  _______,  _______,   _______,  _______,  _______,  _______,  _______,  _______,    _______,  _______,            _______,
         _______,  RGB_TOG,  RGB_MOD,  RGB_VAI,  RGB_HUI,  RGB_SAI,  RGB_SPI,   _______,  _______,  _______,  _______,  _______,  _______,    _______,  _______,            _______,
-        _______,  _______,  RGB_RMOD, RGB_VAD,  RGB_HUD,  RGB_SAD,  RGB_SPD,   KC_LEFT,  KC_DOWN,  KC_UP,    KC_RGHT,  _______,  _______,              _______,            _______,
+        _______,  _______,  RGB_RMOD, RGB_VAD,  RGB_HUD,  RGB_SAD,  RGB_SPD,   KC_LEFT,  KC_DOWN,  KC_UP,    KC_RGHT,  XXXXXXX,  _______,              _______,            _______,
         _______,  _______,            _______,  _______,  _______,  _______,   _______,  NK_TOGG,  _______,  _______,  _______,  _______,              _______,  _______,
         _______,  _______,  _______,  _______,  _______,            _______,                       _______,            _______,  _______,    _______,  _______,  _______,  _______),
     /* INFO: WIN_FN layer (RGB and media control)


### PR DESCRIPTION
DK1 was present in fn layers through transparency, this caused unexpected behavior due to the fact dk1 sends S(KC_6) when hitting some middle row keys (such as K and L), causing the active window to move to workspace 6 This fixes it by just removing Dk1 access from those layers as they are used for arrow keys on \hjkl\ only.